### PR TITLE
add a basic code climate config and corresponding badge to the README

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,17 @@
+---
+engines:
+  duplication:
+    enabled: false
+  fixme:
+    enabled: true
+  govet:
+    enabled: true
+  golint:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.go"
+ 
+exclude_paths:
+ 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Cloud.gov Common Concourse Resource
 ===================================
+[![Code Climate](https://codeclimate.com/github/18F/cg-common-resource/badges/gpa.svg)](https://codeclimate.com/github/18F/cg-common-resource)
 
 Get common concourse files needed for most pipelines.
 


### PR DESCRIPTION
As part of the Fedramp effort, we are required to ensure static code analysis is run on all 18F developed code that is part of the cloud.gov platform:  https://github.com/18F/cg-product/issues/260

In support of this effort, this PR adds a basic code climate configuration and badge to the README.
