### PR TITLE
Support multiple secrets files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,25 @@ If you want to use this resource just add the following to your pipeline:
     bosh_cert: bosh.pem
 ```
 
-This will get you a secrets file decrypted and a bosh UAA certificate.
+This will get you a `secrets.yml` file that is a decrypted version of the `secrets_file` and a bosh UAA certificate, named `boshCA.crt`.
 
+You can also define more than one secrets file by using the plural form `secrets_files`:
+
+```yaml
+- name: common
+  type: cg-common
+  source:
+    bucket_name: {{private-bucket}}
+    access_key_id: {{private-access-key-id}}
+    secret_access_key: {{private-secret-access-key}}
+    region: us-gov-west-1 # optional - defaults to us-east-1 if not provided
+    secrets_files:
+    - something.yml
+    - somethingelse.yml
+    secrets_passphrase: {{private-passphrase}}
+    bosh_cert: bosh.pem
+```
+
+**NOTE:** All files named in `secrets_files` have to be encrypted with the same passphrase.
+
+You will then get a version of each prefixed by `decrypted-`, e.g. `decrypted-something.yml`.

--- a/command.go
+++ b/command.go
@@ -29,6 +29,7 @@ type Source struct {
 	AccessKeyId       string `json:"access_key_id"`
 	SecretAccessKey   string `json:"secret_access_key"`
 	SecretsFile       string `json:"secrets_file"`
+	SecretsFiles      []string  `json:"secrets_files"`
 	SecretsPassphrase string `json:"secrets_passphrase"`
 	BoshCert          string `json:"bosh_cert"`
 	Region            string `json:"region"`
@@ -94,11 +95,20 @@ func main() {
 
 	// Load the files in an array
 	var files []File
-	files = append(files, File{
-		FilePath:   i.Source.SecretsFile,
-		Passphrase: i.Source.SecretsPassphrase,
-		OutputName: "secrets.yml",
-	})
+	if i.Source.SecretsFile != "" {
+		files = append(files, File{
+			FilePath:   i.Source.SecretsFile,
+			Passphrase: i.Source.SecretsPassphrase,
+			OutputName: "secrets.yml",
+		})
+	}
+	for _, f := range i.Source.SecretsFiles {
+		files = append(files, File{
+			FilePath:   f,
+			Passphrase: i.Source.SecretsPassphrase,
+			OutputName: "decrypted-" + f,
+		})
+	}
 	files = append(files, File{
 		FilePath:   i.Source.BoshCert,
 		OutputName: "boshCA.crt",

--- a/compile.yml
+++ b/compile.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: "1.6"
+    tag: "1.8"
 
 inputs:
   - name: cg-common-resource


### PR DESCRIPTION
In prep for splitting out non-rotatable secrets, there's a good chance that our pipelines will now include multiple secrets files (at least, for a while until everything else is generated). This will support that going forward, and retains backward compatibility.